### PR TITLE
Remove polyfill script [URGENT]

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,7 +115,6 @@ plugins:
 
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 copyright : Intermediate Shell for Bioinformatics workshop material is licensed under a <a rel="noopener" target="_blank" href="https://www.gnu.org/licenses/gpl-3.0.en.html">GNU General Public License v3.0</a>


### PR DESCRIPTION
Polyfill was compromised in 2024, it now injects malicious code that prompts users for a login and password.

It's removal should only impact people using really old web browsers.

Super duper needs to be removed before the workshop. @chloevdb 